### PR TITLE
[Chore]: Change otp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t hive-elixir:1.11-alpine ./
 
 # base image elixer to start with
-FROM elixir:1.14.5-alpine
+FROM elixir:1.14.5-otp-25-alpine
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8


### PR DESCRIPTION
### Chore

A versão padrão do OTP na tag 11.14.5-alpine é a 26, isso estava causando um erro na compilação de dependências:

![image](https://github.com/yubeio/docker-elixir/assets/39491820/22832cc2-c7b4-4824-b1e1-b56c06da2900)

Substituído pela tag: 1.14.5-otp-25-alpine
